### PR TITLE
Fix: Remove unused parameter in create_mds_p function

### DIFF
--- a/plugins/arkworks/src/poseidon/parameters_hardcoded_test/generate_parameters_grain_deterministic.sage
+++ b/plugins/arkworks/src/poseidon/parameters_hardcoded_test/generate_parameters_grain_deterministic.sage
@@ -97,7 +97,7 @@ def print_round_constants_arkff(round_constants):
     print("Round constants for ark-ff:")
     print("vec![" + ",".join(['Fp(field_new!(Fr, "{}"))'.format(int(entry)) for entry in round_constants]) + "]")
 
-def create_mds_p(n, t):
+def create_mds_p(t):
     M = matrix(F, t, t)
 
     # Sample random distinct indices and assign to xs and ys
@@ -244,12 +244,12 @@ def generate_matrix(FIELD, FIELD_SIZE, NUM_CELLS):
         print("Matrix generation not implemented for GF(2^n).")
         exit(1)
     elif FIELD == 1:
-        mds_matrix = create_mds_p(FIELD_SIZE, NUM_CELLS)
+        mds_matrix = create_mds_p(NUM_CELLS)
         result_1 = algorithm_1(mds_matrix, NUM_CELLS)
         result_2 = algorithm_2(mds_matrix, NUM_CELLS)
         result_3 = algorithm_3(mds_matrix, NUM_CELLS)
         while result_1[0] == False or result_2[0] == False or result_3[0] == False:
-            mds_matrix = create_mds_p(FIELD_SIZE, NUM_CELLS)
+            mds_matrix = create_mds_p(NUM_CELLS)
             result_1 = algorithm_1(mds_matrix, NUM_CELLS)
             result_2 = algorithm_2(mds_matrix, NUM_CELLS)
             result_3 = algorithm_3(mds_matrix, NUM_CELLS)


### PR DESCRIPTION
Removed unused parameter n from create_mds_p function in plugins/arkworks/src/poseidon/parameters_hardcoded_test/generate_parameters_grain_deterministic.sage and updated function calls accordingly to improve code consistency and maintainability.